### PR TITLE
fix(tungstenite): Update crate for rustls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ serde_qs = "0.9.2"
 url = "2.1.1"
 tap-reader = "1"
 toml = { version = "0.5.0", optional = true }
-tungstenite = "0.11.0"
+tungstenite = "0.17"
 async-trait = "0.1.40"
 async-h1 = { version = "2.1.2", optional = true }
 async-native-tls = { version = "0.3.3", optional = true }
@@ -45,7 +45,7 @@ default = ["reqwest/default-tls"]
 json = []
 env = ["envy"]
 all = ["toml", "json", "env", "async"]
-rustls-tls = ["reqwest/rustls-tls"]
+rustls-tls = ["reqwest/rustls-tls", "tungstenite/rustls-tls-webpki-roots"]
 nightly = []
 async = ["async-h1", "async-native-tls", "smol", "http-types", "async-mutex"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,8 @@
 use std::{borrow::Cow, io::BufRead, ops};
 
 use reqwest::blocking::{Client, RequestBuilder, Response};
-use tungstenite::client::AutoStream;
+use std::net::TcpStream;
+use tungstenite::stream::MaybeTlsStream;
 
 use crate::{entities::prelude::*, page::Page};
 
@@ -649,7 +650,7 @@ impl MastodonClient for Mastodon {
 #[derive(Debug)]
 /// WebSocket newtype so that EventStream can be implemented without coherency
 /// issues
-pub struct WebSocket(tungstenite::protocol::WebSocket<AutoStream>);
+pub struct WebSocket(tungstenite::protocol::WebSocket<MaybeTlsStream<TcpStream>>);
 
 /// A type that streaming events can be read from
 pub trait EventStream {


### PR DESCRIPTION
Problem: Even if I set the feature flag `rustls-tls` for Elefren I end up with an OpenSSL dependency, which I don't want.

Solution: upgrade tungstenite which supports rustls now, then we can forward that feature flag.