### PR TITLE
fix(time): Remove time crate dependency, switch to parse_link_header crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,9 +17,9 @@ edition = "2021"
 [dependencies]
 doc-comment = "0.3.3"
 envy = { version = "0.4.2", optional = true }
-hyper-old-types = "0.11.0"
 isolang = { version = "2.1.0", features = ["serde"] }
 log = "0.4.17"
+parse_link_header = { version = "0.3", features = ["url"] }
 reqwest = { version = "0.11.11", default-features = false, features = ["json", "blocking", "multipart"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -38,6 +38,10 @@ async-mutex = { version = "1.4.0", optional = true }
 
 [dependencies.chrono]
 version = "0.4"
+# Switching off default features removes a dependency to the "time" crate that
+# contains a potential security issue.
+# See https://github.com/time-rs/time/issues/293
+default-features = false
 features = ["serde"]
 
 [features]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -11,7 +11,7 @@ use async_native_tls::Error as TlsError;
 use envy::Error as EnvyError;
 #[cfg(feature = "async")]
 use http_types::Error as HttpTypesError;
-use hyper_old_types::Error as HeaderParseError;
+use parse_link_header::Error as HeaderParseError;
 use reqwest::{header::ToStrError as HeaderStrError, Error as HttpError, StatusCode};
 use serde_json::Error as SerdeError;
 use serde_qs::Error as SerdeQsError;


### PR DESCRIPTION
Problem: Github Dependabot reports a security issue in the time crate from https://github.com/chronotope/chrono/issues/602

The time crate is an optional dependency of chrono, so we can disable it.

The time crate is also a dependency of hyper-old-types which we can replace with parse_link_header.